### PR TITLE
Math Magicians: Deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,18 @@ You can find live project at https://amrendrakind.github.io/math-magicians/
 
 ## Live Demo (Link for My Math Magicians Project)
 
-[Live Demo Link](https://amrendrakind.github.io/math-magicians)
+### Github
+
+Take a look at the Math Magician page [Math Magician@GitHub](https://amrendrakind.github.io/math-magicians)
+
+### Heroku
+
+Take a look at the Math Magician page [Math Magician@Heroku](https://math-magician0.herokuapp.com/)
+
+
+### Netlify
+
+Take a look at the Math Magician page [link]()
 
 ## Development set up
 
@@ -87,6 +98,12 @@ You don't have to ever use `eject`. The curated feature set is suitable for smal
 - GitHub: [@githubhandle](https://github.com/amrendrakind)
 - Twitter: [@twitterhandle](https://twitter.com/amrendrak_)
 - LinkedIn: [LinkedIn](https://linkedin.com/in/amrendraakumar)
+
+## 🤝 Contribution
+
+- GitHub: [@githubhandle](https://github.com/Ol-create)
+- Twitter: [@twitterhandle](https://twitter.com/OluyemiPaul99)
+- LinkedIn: [LinkedIn](https://www.linkedin.com/in/paul-oluyemi-193966ab)
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ You don't have to ever use `eject`. The curated feature set is suitable for smal
 
 ## 🤝 Contribution
 
+👤 **Paul Oluyemi**
+
 - GitHub: [@githubhandle](https://github.com/Ol-create)
 - Twitter: [@twitterhandle](https://twitter.com/OluyemiPaul99)
 - LinkedIn: [LinkedIn](https://www.linkedin.com/in/paul-oluyemi-193966ab)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Take a look at the Math Magician page [Math Magician@Heroku](https://math-magici
 
 ### Netlify
 
-Take a look at the Math Magician page [link]()
+Take a look at the Math Magician page [Math Magician@Netlify](https://math-magicians0.netlify.app/)
 
 ## Development set up
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,0 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});


### PR DESCRIPTION
**Math Magicians: Deployment**

- Use Heroku to deploy the Math Magicians app.
- Use Netlify to deploy the Math Magicians app.
- Add 2 links to the deployed applications (Heroku and Netlify) to the README file in your GitHub repo.